### PR TITLE
Fix version command when run in executable

### DIFF
--- a/src/getVersion.ts
+++ b/src/getVersion.ts
@@ -3,11 +3,12 @@ import path from 'path';
 
 import { hasKey } from './utils';
 
-const fsPromises = fs.promises;
-
-export const getVersionNumber = async (): Promise<string> => {
+export const getVersionNumber = (): string => {
     const packagePath = path.join(__dirname, '..', 'package.json');
-    const packageData = await fsPromises.readFile(packagePath, 'utf8');
+    // Using fs.promises here doesn't work with reading assets from
+    // within the pkg executable snapshot filesystem, so just
+    // `readFileSync` instead
+    const packageData = fs.readFileSync(packagePath, 'utf8');
     let parsed: unknown;
     try {
         parsed = JSON.parse(packageData);

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,7 @@ export const main = async (args: Array<string>): Promise<void> => {
     }
 
     if (positionalArgs[0] === 'version') {
-        console.log(await getVersionNumber());
+        console.log(getVersionNumber());
         return;
     }
 


### PR DESCRIPTION
Using `fs.promises` doesn't work when reading assets from the pkg snapshot filesystem.