### PR TITLE
Install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,30 @@ The Linux installation guide is here:
 
 https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
 
+## Installation
+
+Oneline:
+```
+$ bash <(curl "https://raw.githubusercontent.com/isotoma/aws-sso-auth/master/install.sh")
+
+```
+
+Or, if you don't like running scripts from the internet:
+- download an executable from https://github.com/isotoma/aws-sso-auth/releases
+- make it executable with `chmod a+x`
+- put it somewhere that is on your `$PATH`
+
+Or, if you don't trust those executables:
+- Checkout this repository
+- Run `npm run package`
+- Take one of the executables from `./dist/`
+- put it somewhere that is on your `$PATH`
+
+Or, if you don't trust executables made by pkg:
+- Checkout this repository
+- Run `npm run build`
+- Alias `node /path/to/repo/build/bin.js` to `aws-sso-auth`
+
 ## Usage
 
 You will need to have a current SSO session with the AWS CLI. Before using the AWS CLI for SSO you need to configure it with `aws sso configure`. Note that `aws-sso-auth` currently expects you to be using a profile called `default` for your sso login.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,67 @@
+#!/bin/bash -e
+
+function stderr() {
+    >&2 echo "$1"
+}
+
+function error() {
+    stderr "Error: $1"
+    exit 1
+}
+
+function info() {
+    stderr "Info: $1"
+}
+    
+
+function main() {
+    info "Finding latest version..."
+    latest_version="$(curl --silent --header 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/isotoma/aws-sso-auth/releases | grep tag_name | head -n 1 | sed -e 's/.*:\s*//' -e 's/^"//' -e 's/",\?$//')"
+    platform_uname="$(uname -s)"
+    case "$platform_uname" in
+        Linux*)
+            platform=linux
+            ;;
+        Darwin*)
+            platform=mac
+            ;;
+        *)
+            error "Unknown platform: $platform_uname"
+            ;;
+    esac
+
+    info "Downloading to temporary directory..."
+    download_url="https://github.com/isotoma/aws-sso-auth/releases/download/$latest_version/aws-sso-auth-$platform"
+    tmp_dir="$(mktemp -d -t aws-sso-auth-XXXXXXXX)"
+    tmp_download_path="$tmp_dir/aws-sso-auth"
+    curl --silent --location "$download_url" --output "$tmp_download_path"
+
+    target_directory_path="/usr/local/bin/aws-sso-auth"
+
+    info "Will install aws-sso-auth executable version=$latest_version, platform=$platform to $target_directory_path"
+    info "  Downloaded from: $download_url"
+    info "  MD5 checksum: $(md5sum $tmp_download_path || echo unknown)"
+
+    read -p "Are you sure? " -r
+    if [[ ! $REPLY =~ ^(Y|y|yes)$ ]]
+    then
+        rm -rf "$tmp_dir"
+        error "Not confirmed, exiting"
+    fi
+
+    info "Installing..."
+    install -T "$tmp_download_path" "$target_directory_path" || {
+        info "Trying again with sudo..."
+        sudo install -T --owner=root --group=root "$tmp_download_path" "$target_directory_path"
+    }
+
+    rm -rf "$tmp_dir"
+
+    info "Installation succeeded, checking if on PATH using 'which aws-sso-auth'"
+    which aws-sso-auth
+
+    info "And checking installed version using 'aws-sso-auth version'"
+    aws-sso-auth version
+}
+
+main


### PR DESCRIPTION
Fixes #13

Bash script to handle installation to `/usr/local/bin/aws-sso-auth` because I think that is the correct place.

Added instructions about other installation options.