### PR TITLE
Session token expiry workaround

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -27,3 +27,7 @@ export class UnexpectedGetRoleCredentialsOutputError extends ApplicationError {
 export class BadAWSCLIVersionError extends ApplicationError {
     readonly prefix = 'BadAWSCLIVersionError';
 }
+
+export class MisbehavingExpiryDateError extends ApplicationError {
+    readonly prefix = 'MisbehavingExpiryDateError';
+}


### PR DESCRIPTION
Fixes #23 

If running `aws sso get-role-credentials` fails with an error complaining about the token having expired, run `aws sso login` and try again (even though we just checked the claimed expiry date in the cache file).

However, if we ran `aws sso login` mere moments ago, do not retry and just error out.