### PR TITLE
Use node v14

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Use Node.js 12
+      - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         run: npm ci
       - name: Build assets

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "",
   "bin": "bin.js",
   "engines": {
-    "node": ">=12.13.0 <13",
-    "npm": ">=6.11.0 <7"
+    "node": ">=14.15.5 <15",
+    "npm": ">=6.14.11 <7"
   },
   "scripts": {
     "build": "rm -rf build/ && npm run -- tsc --project ./tsconfig.dist.json --noEmitOnError --outDir ./build && cp package.json package-lock.json README.md ./build/ && (cd ./build && npm ci --only=production)",
-    "package": "npm run build && rm -rf dist/ && mkdir -p dist && npm run -- pkg ./build --out-path ./dist",
+    "package": "npm run build && rm -rf dist/ && mkdir -p dist && npm run -- pkg ./build --targets=node14-linux-x64,node14-macos-x64,node14-win-x64 --out-path ./dist",
     "pkg": "pkg",
     "compile": "npm run tsc --noEmitOnError",
     "version": "auto-changelog --template ./changelog_template.hbs -p && git add CHANGELOG.md",


### PR DESCRIPTION
Both in dev and in distributed pkg executables

v14 is the current LTS, so is the obvious choice here.