### PR TITLE
Expiry issue

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -115,7 +115,11 @@ export const run = async (props: RunProps): Promise<void> => {
         awsProfile: props.profile,
     };
 
-    if (typeof ssoLoginContext.latestCacheFile === 'undefined' || ssoLoginContext.latestCacheFile.expiresAt.getTime() < new Date().getTime()) {
+    const date = new Date()
+    // Token actually expires 10 minutes earlier than expected
+    date.setMinutes(date.getMinutes() - 10)
+
+    if (typeof ssoLoginContext.latestCacheFile === 'undefined' || ssoLoginContext.latestCacheFile.expiresAt.getTime() < date.getTime()) {
         await runSsoLogin(ssoLoginContext);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,9 +115,9 @@ export const run = async (props: RunProps): Promise<void> => {
         awsProfile: props.profile,
     };
 
-    const date = new Date()
+    const date = new Date();
     // Token actually expires 10 minutes earlier than expected
-    date.setMinutes(date.getMinutes() - 10)
+    date.setMinutes(date.getMinutes() - 10);
 
     if (typeof ssoLoginContext.latestCacheFile === 'undefined' || ssoLoginContext.latestCacheFile.expiresAt.getTime() < date.getTime()) {
         await runSsoLogin(ssoLoginContext);


### PR DESCRIPTION
The AWS Credentials actually expire 10 minutes before their expiry time, so this will trigger getting a new token when the old one has actually expired.